### PR TITLE
Use global env to avoid redefined plugin for each env

### DIFF
--- a/generators/todoMVC/index.js
+++ b/generators/todoMVC/index.js
@@ -12,12 +12,7 @@ module.exports = fountain.Base.extend({
     },
 
     babel() {
-      this.mergeJson('.babelrc', {
-        env: {
-          development: {plugins: ['transform-object-rest-spread']},
-          production: {plugins: ['transform-object-rest-spread']}
-        }
-      });
+      this.mergeJson('.babelrc', {plugins: ['transform-object-rest-spread']});
     }
   },
 

--- a/test/todoMVC/index.js
+++ b/test/todoMVC/index.js
@@ -44,7 +44,7 @@ test(`Add 'todomvc-app-css' to package.json dependencies`, () => {
 
 test(`Add 'transform-object-rest-spread' to babelrc`, () => {
   TestUtils.call(context, 'configuring.babel');
-  expect(context.mergeJson['.babelrc'].env.production.plugins).to.deep.equal(['transform-object-rest-spread']);
+  expect(context.mergeJson['.babelrc'].plugins).to.deep.equal(['transform-object-rest-spread']);
 });
 
 test(`Call this.copyTemplate 20 times`, t => {


### PR DESCRIPTION
https://babeljs.io/docs/usage/babelrc/


>Options specific to a certain environment are merged into and overwrite non-env specific options.