### PR TITLE
Add :key to techs in v-for

### DIFF
--- a/generators/techs/templates/src/app/techs/Techs.vue
+++ b/generators/techs/templates/src/app/techs/Techs.vue
@@ -4,7 +4,7 @@
       Cooked with all these awesome technologies:
     </h2>
     <div class="techs">
-      <tech v-for="tech in techs" :tech="tech"></tech>
+      <tech v-for="tech in techs" :tech="tech" :key="tech.key"></tech>
     </div>
   </div>
 </template>


### PR DESCRIPTION
fixes issue:

```
WARNING in ./~/vue-loader/lib/template-compiler.js?{"id":"data-v-30277f8a"}!./~/vue-loader/lib/selector.js?type=template&index=0!./src/app/techs/Techs.vue
<tech v-for="tech in techs">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.
 @ ./src/app/techs/Techs.vue 5:2-178
 @ ./~/babel-loader/lib!./~/vue-loader/lib/selector.js?type=script&index=0!./src/app/Main.vue
 @ ./src/app/Main.vue
 @ ./src/index.js
```